### PR TITLE
Add weather-aware seasonal bias, physics floor for severe AQI, temporal split and cyclical features

### DIFF
--- a/app.py
+++ b/app.py
@@ -135,6 +135,15 @@ def calculate_indian_aqi(pm25: float, pm10: float) -> float:
     val_pm10 = get_sub_index(pm10, pm10_breakpoints)
     return max(val_pm25, val_pm10)
 
+
+def apply_physics_floor(predicted_aqi: float, pm25: float, pm10: float) -> float:
+    """Apply floor only for severe pollution episodes to avoid high bias."""
+    cpcb_val = calculate_indian_aqi(pm25, pm10)
+    severe_episode = (pm25 >= 250) or (pm10 >= 350)
+    if severe_episode:
+        return max(predicted_aqi, cpcb_val)
+    return predicted_aqi
+
 def aqi_category(aqi: float) -> Dict:
     if aqi <= 50: return {"cat": "Good", "emoji": "🟢", "color": "#00e400"}
     elif aqi <= 100: return {"cat": "Satisfactory", "emoji": "🟡", "color": "#ffff00"}
@@ -148,31 +157,23 @@ def aqi_category(aqi: float) -> Dict:
 # =============================================================================
 
 def get_seasonal_multiplier(month: int, region_type: str) -> float:
-    """
-    Determines multiplier based on Indian Seasons.
-    1. Nov-Jan: Peak Smog (High)
-    2. Feb-May: Dust/Heat (Medium-High)
-    3. Jun-Sep: Monsoon (Low/Normal)
-    4. Oct: Transition (High)
-    """
-    # PEAK WINTER (Smog)
+    """Conservative seasonal prior used as a soft adjustment."""
     if month in [11, 12, 1]:
-        return 1.8 if region_type == "North" else 1.3
-    
-    # SUMMER / DUST SEASON (Current Season: Feb-May)
-    # North India has high dust load, South has humidity
+        return 1.18 if region_type == "North" else 1.08
     if month in [2, 3, 4, 5]:
-        return 1.4 if region_type == "North" else 1.2
-    
-    # MONSOON (Rain washes pollutants)
+        return 1.10 if region_type == "North" else 1.05
     if month in [6, 7, 8, 9]:
-        return 1.0 # Trust the model (rain is hard to bias)
-
-    # POST-MONSOON / PRE-WINTER (Crop Burning starts)
+        return 0.96 if region_type == "North" else 0.94
     if month in [10]:
-        return 1.6 if region_type == "North" else 1.2
-        
-    return 1.1
+        return 1.14 if region_type == "North" else 1.05
+    return 1.0
+
+def _weather_damping_factor(df: pd.DataFrame) -> pd.Series:
+    """Row-wise damping so seasonal prior doesn't over-correct."""
+    rainfall = (df.get('cloud_cover', 0).fillna(0) / 100.0).clip(0.0, 1.0)
+    wind = (df.get('wind_speed_10m', 0).fillna(0) / 30.0).clip(0.0, 1.0)
+    # More wind/cloud usually disperses pollutants; shrink seasonal boost in such cases.
+    return (1.0 - 0.35 * rainfall - 0.25 * wind).clip(0.65, 1.0)
 
 def apply_indian_context_bias(df: pd.DataFrame, city: str):
     if df.empty: return df
@@ -194,14 +195,16 @@ def apply_indian_context_bias(df: pd.DataFrame, city: str):
     # Get Dynamic Multiplier
     multiplier = get_seasonal_multiplier(current_month, region_type)
     
-    # Apply multiplier
-    if multiplier > 1.0:
-        df['pm2_5'] = df['pm2_5'] * multiplier
-        df['pm10'] = df['pm10'] * (multiplier * 0.95)
-        
-        # Nitrogen Dioxide bias for Metros (Traffic)
-        if region_type == "Metro" or region_type == "North":
-             df['nitrogen_dioxide'] = df['nitrogen_dioxide'] * 1.2
+    # Apply conservative and weather-aware multiplier
+    weather_factor = _weather_damping_factor(df)
+    effective_multiplier = 1.0 + (multiplier - 1.0) * weather_factor
+
+    df['pm2_5'] = df['pm2_5'] * effective_multiplier
+    df['pm10'] = df['pm10'] * (effective_multiplier * 0.97)
+
+    if region_type in ["Metro", "North"]:
+        no2_multiplier = 1.0 + 0.08 * weather_factor
+        df['nitrogen_dioxide'] = df['nitrogen_dioxide'] * no2_multiplier
 
     return df
 
@@ -278,10 +281,12 @@ def prepare_features(weather: Dict, air_quality: Dict, city: str) -> Optional[pd
     
     df = pd.DataFrame(rows) if rows else None
     
-    # APPLY BIAS (Now handles Year-Round logic, not just winter)
+    # Keep raw pollutant values for calibration/output, then apply model-only contextual bias
     if df is not None:
+        for col in ['pm2_5', 'pm10', 'nitrogen_dioxide']:
+            df[f'raw_{col}'] = df[col]
         df = apply_indian_context_bias(df, city)
-        
+
     return df
 
 # =============================================================================
@@ -350,8 +355,9 @@ def predict_city_aqi(city: str, days: int = 2):
     
     final_aqi = []
     for i, pred in enumerate(raw_predictions):
-        cpcb_val = calculate_indian_aqi(df.iloc[i]['pm2_5'], df.iloc[i]['pm10'])
-        final_aqi.append(max(float(pred), cpcb_val))
+        pm25_raw = float(df.iloc[i].get('raw_pm2_5', df.iloc[i]['pm2_5']))
+        pm10_raw = float(df.iloc[i].get('raw_pm10', df.iloc[i]['pm10']))
+        final_aqi.append(apply_physics_floor(float(pred), pm25_raw, pm10_raw))
     df['aqi'] = final_aqi
     
     hourly_forecast = []
@@ -360,8 +366,8 @@ def predict_city_aqi(city: str, days: int = 2):
         hourly_forecast.append({
             "datetime": row['datetime'].isoformat(), "hour": int(row['hour']),
             "aqi": round(row['aqi'], 1), "category": cat["cat"], "emoji": cat["emoji"], "color": cat["color"],
-            "pm2_5": round(row['pm2_5'], 1), "pm10": round(row['pm10'], 1),
-            "ozone": round(row['ozone'], 1), "nitrogen_dioxide": round(row['nitrogen_dioxide'], 1),
+            "pm2_5": round(row.get('raw_pm2_5', row['pm2_5']), 1), "pm10": round(row.get('raw_pm10', row['pm10']), 1),
+            "ozone": round(row['ozone'], 1), "nitrogen_dioxide": round(row.get('raw_nitrogen_dioxide', row['nitrogen_dioxide']), 1),
             "sulphur_dioxide": round(row['sulphur_dioxide'], 1), "carbon_monoxide": round(row['carbon_monoxide'], 1),
             "relative_humidity_2m": round(row['relative_humidity_2m'], 1), "wind_speed_10m": round(row['wind_speed_10m'], 1)
         })
@@ -395,11 +401,12 @@ def process_single_city(city_name: str) -> Optional[Dict]:
             df = prepare_features(weather, air_quality, city_name)
             if df is not None and len(df) > 0:
                 current_row = df.iloc[[0]].copy() 
-                cpcb_val = calculate_indian_aqi(current_row['pm2_5'].values[0], current_row['pm10'].values[0])
+                pm25_raw = float(current_row.get('raw_pm2_5', current_row['pm2_5']).values[0])
+                pm10_raw = float(current_row.get('raw_pm10', current_row['pm10']).values[0])
                 X = current_row[REQUIRED_FEATURES].values.astype(np.float32); X = np.nan_to_num(X, nan=0.0)
                 dmatrix = xgb.DMatrix(X, feature_names=REQUIRED_FEATURES)
                 pred = float(model.predict(dmatrix)[0])
-                final_aqi = max(pred, cpcb_val)
+                final_aqi = apply_physics_floor(pred, pm25_raw, pm10_raw)
                 cat = aqi_category(final_aqi)
                 return {
                     "city": city_name, "state": city_info['state'],

--- a/params.yaml
+++ b/params.yaml
@@ -82,7 +82,7 @@ feature_engineering:
     - "state"
   encoding_method: "label"
   
-  create_cyclical_features: false
+  create_cyclical_features: true
   create_interaction_features: false
   create_lag_features: false
   create_rolling_features: false
@@ -128,7 +128,8 @@ data_splitting:
   output_dir: "data/splits"
   test_size: 0.15
   validation_size: 0.15
-  stratify: true
+  split_method: "time"
+  stratify: false
   stratify_bins: [0, 50, 100, 150, 200, 300, 500, 1000]
 
 # ----- Model Training Parameters -----

--- a/src/components/data_splitting.py
+++ b/src/components/data_splitting.py
@@ -41,6 +41,7 @@ class DataSplitting:
         
         self.test_size = split_config.get("test_size", 0.15)
         self.validation_size = split_config.get("validation_size", 0.15)
+        self.split_method = split_config.get("split_method", "random")
         
         # Stratification settings (from notebook)
         self.stratify = split_config.get("stratify", True)
@@ -61,6 +62,7 @@ class DataSplitting:
         logger.info("Data Splitting initialized")
         logger.info(f"Test size: {self.test_size*100:.0f}%")
         logger.info(f"Validation size: {self.validation_size*100:.0f}%")
+        logger.info(f"Split method: {self.split_method}")
         logger.info(f"Stratified: {self.stratify}")
     
     def run(self) -> Tuple[str, str, str]:
@@ -101,111 +103,141 @@ class DataSplitting:
         city_col = df['city'].copy() if 'city' in df.columns else None
         state_col = df['state'].copy() if 'state' in df.columns else None
         
-        # Step 4: Create stratification bins (from notebook)
-        if self.stratify:
-            logger.info(f"\n4. Creating stratification bins")
-            y_bins = pd.cut(y, bins=self.stratify_bins, labels=False)
-            logger.info(f"   Bins: {self.stratify_bins}")
-            logger.info(f"   Distribution:")
-            for i, (low, high) in enumerate(zip(self.stratify_bins[:-1], self.stratify_bins[1:])):
-                count = (y_bins == i).sum()
-                pct = count / len(y_bins) * 100
-                logger.info(f"     {low:>4} - {high:>4}: {count:>7,} ({pct:>5.2f}%)")
+        # Step 4: Split data
+        if self.split_method == "time" and datetime_col is not None:
+            logger.info(f"\n4. Performing temporal split (no shuffling)")
+
+            order = np.argsort(datetime_col.values)
+            X_sorted = X.iloc[order].reset_index(drop=True)
+            y_sorted = y.iloc[order].reset_index(drop=True)
+            dt_sorted = datetime_col.iloc[order].reset_index(drop=True)
+            city_sorted = city_col.iloc[order].reset_index(drop=True) if city_col is not None else None
+            state_sorted = state_col.iloc[order].reset_index(drop=True) if state_col is not None else None
+
+            n_total = len(X_sorted)
+            n_test = int(round(n_total * self.test_size))
+            n_val = int(round(n_total * self.validation_size))
+            n_train = n_total - n_val - n_test
+
+            if n_train <= 0 or n_val <= 0 or n_test <= 0:
+                raise ValueError("Invalid split sizes for temporal split")
+
+            X_train = X_sorted.iloc[:n_train]
+            X_val = X_sorted.iloc[n_train:n_train + n_val]
+            X_test = X_sorted.iloc[n_train + n_val:]
+
+            y_train = y_sorted.iloc[:n_train]
+            y_val = y_sorted.iloc[n_train:n_train + n_val]
+            y_test = y_sorted.iloc[n_train + n_val:]
+
+            dt_train = dt_sorted.iloc[:n_train]
+            dt_val = dt_sorted.iloc[n_train:n_train + n_val]
+            dt_test = dt_sorted.iloc[n_train + n_val:]
+
+            city_train = city_sorted.iloc[:n_train] if city_sorted is not None else None
+            city_val = city_sorted.iloc[n_train:n_train + n_val] if city_sorted is not None else None
+            city_test = city_sorted.iloc[n_train + n_val:] if city_sorted is not None else None
+
+            state_train = state_sorted.iloc[:n_train] if state_sorted is not None else None
+            state_val = state_sorted.iloc[n_train:n_train + n_val] if state_sorted is not None else None
+            state_test = state_sorted.iloc[n_train + n_val:] if state_sorted is not None else None
+
         else:
-            y_bins = None
-        
-        # Step 5: First split - separate test set (from notebook)
-        logger.info(f"\n5. Splitting data (stratified random)")
-        
-        split_data = [X, y]
-        if datetime_col is not None:
-            split_data.append(datetime_col)
-        if city_col is not None:
-            split_data.append(city_col)
-        if state_col is not None:
-            split_data.append(state_col)
-        if y_bins is not None:
-            split_data.append(y_bins)
-        
-        # First split: train+val vs test
-        # train_test_split returns: X_temp, X_test, y_temp, y_test, dt_temp, dt_test, etc.
-        split_result = train_test_split(
-            *split_data,
-            test_size=self.test_size,
-            random_state=self.random_state,
-            stratify=y_bins if self.stratify else None,
-            shuffle=True
-        )
-        
-        # Unpack results (order: temp, test, temp, test, ...)
-        # For n inputs, we get 2*n outputs (alternating temp and test)
-        n_inputs = len(split_data)
-        X_temp = split_result[0]
-        X_test = split_result[1]
-        y_temp = split_result[2]
-        y_test = split_result[3]
-        
-        idx = 4
-        dt_temp = split_result[idx] if datetime_col is not None else None
-        dt_test = split_result[idx + 1] if datetime_col is not None else None
-        idx += 2 if datetime_col is not None else 0
-        
-        city_temp = split_result[idx] if city_col is not None else None
-        city_test = split_result[idx + 1] if city_col is not None else None
-        idx += 2 if city_col is not None else 0
-        
-        state_temp = split_result[idx] if state_col is not None else None
-        state_test = split_result[idx + 1] if state_col is not None else None
-        idx += 2 if state_col is not None else 0
-        
-        bins_temp = split_result[idx] if y_bins is not None else None
-        bins_test = split_result[idx + 1] if y_bins is not None else None
-        
-        # Second split: train vs validation (from notebook)
-        val_size_adjusted = self.validation_size / (1 - self.test_size)
-        
-        # Second split: train vs validation
-        temp_data2 = [X_temp, y_temp]
-        if dt_temp is not None:
-            temp_data2.append(dt_temp)
-        if city_temp is not None:
-            temp_data2.append(city_temp)
-        if state_temp is not None:
-            temp_data2.append(state_temp)
-        
-        split_result2 = train_test_split(
-            *temp_data2,
-            test_size=val_size_adjusted,
-            random_state=self.random_state,
-            stratify=bins_temp if self.stratify else None,
-            shuffle=True
-        )
-        
-        # Extract train and val data
-        X_train = split_result2[0]
-        X_val = split_result2[1]
-        y_train = split_result2[2]
-        y_val = split_result2[3]
-        
-        idx = 4
-        dt_train = split_result2[idx] if dt_temp is not None else None
-        dt_val = split_result2[idx + 1] if dt_temp is not None else None
-        idx += 2 if dt_temp is not None else 0
-        
-        city_train = split_result2[idx] if city_temp is not None else None
-        city_val = split_result2[idx + 1] if city_temp is not None else None
-        idx += 2 if city_temp is not None else 0
-        
-        state_train = split_result2[idx] if state_temp is not None else None
-        state_val = split_result2[idx + 1] if state_temp is not None else None
-        
+            # Step 4: Create stratification bins (from notebook)
+            if self.stratify:
+                logger.info(f"\n4. Creating stratification bins")
+                y_bins = pd.cut(y, bins=self.stratify_bins, labels=False)
+                logger.info(f"   Bins: {self.stratify_bins}")
+                logger.info(f"   Distribution:")
+                for i, (low, high) in enumerate(zip(self.stratify_bins[:-1], self.stratify_bins[1:])):
+                    count = (y_bins == i).sum()
+                    pct = count / len(y_bins) * 100
+                    logger.info(f"     {low:>4} - {high:>4}: {count:>7,} ({pct:>5.2f}%)")
+            else:
+                y_bins = None
+
+            # Step 5: First split - separate test set (from notebook)
+            logger.info(f"\n5. Splitting data (stratified random)")
+
+            split_data = [X, y]
+            if datetime_col is not None:
+                split_data.append(datetime_col)
+            if city_col is not None:
+                split_data.append(city_col)
+            if state_col is not None:
+                split_data.append(state_col)
+            if y_bins is not None:
+                split_data.append(y_bins)
+
+            split_result = train_test_split(
+                *split_data,
+                test_size=self.test_size,
+                random_state=self.random_state,
+                stratify=y_bins if self.stratify else None,
+                shuffle=True
+            )
+
+            X_temp = split_result[0]
+            X_test = split_result[1]
+            y_temp = split_result[2]
+            y_test = split_result[3]
+
+            idx = 4
+            dt_temp = split_result[idx] if datetime_col is not None else None
+            dt_test = split_result[idx + 1] if datetime_col is not None else None
+            idx += 2 if datetime_col is not None else 0
+
+            city_temp = split_result[idx] if city_col is not None else None
+            city_test = split_result[idx + 1] if city_col is not None else None
+            idx += 2 if city_col is not None else 0
+
+            state_temp = split_result[idx] if state_col is not None else None
+            state_test = split_result[idx + 1] if state_col is not None else None
+            idx += 2 if state_col is not None else 0
+
+            bins_temp = split_result[idx] if y_bins is not None else None
+
+            val_size_adjusted = self.validation_size / (1 - self.test_size)
+            temp_data2 = [X_temp, y_temp]
+            if dt_temp is not None:
+                temp_data2.append(dt_temp)
+            if city_temp is not None:
+                temp_data2.append(city_temp)
+            if state_temp is not None:
+                temp_data2.append(state_temp)
+
+            split_result2 = train_test_split(
+                *temp_data2,
+                test_size=val_size_adjusted,
+                random_state=self.random_state,
+                stratify=bins_temp if self.stratify else None,
+                shuffle=True
+            )
+
+            X_train = split_result2[0]
+            X_val = split_result2[1]
+            y_train = split_result2[2]
+            y_val = split_result2[3]
+
+            idx = 4
+            dt_train = split_result2[idx] if dt_temp is not None else None
+            dt_val = split_result2[idx + 1] if dt_temp is not None else None
+            idx += 2 if dt_temp is not None else 0
+
+            city_train = split_result2[idx] if city_temp is not None else None
+            city_val = split_result2[idx + 1] if city_temp is not None else None
+            idx += 2 if city_temp is not None else 0
+
+            state_train = split_result2[idx] if state_temp is not None else None
+            state_val = split_result2[idx + 1] if state_temp is not None else None
+
         logger.info(f"   OK Split complete:")
         logger.info(f"     Train: {len(X_train):,} ({len(X_train)/len(df)*100:.1f}%)")
         logger.info(f"     Val:   {len(X_val):,} ({len(X_val)/len(df)*100:.1f}%)")
         logger.info(f"     Test:  {len(X_test):,} ({len(X_test)/len(df)*100:.1f}%)")
         
         # Step 6: Verify stratification (from notebook)
-        if self.stratify:
+        if self.stratify and self.split_method != "time":
             logger.info(f"\n6. Verifying stratification")
             self._verify_stratification(y_train, y_val, y_test)
         

--- a/src/components/feature_engineering.py
+++ b/src/components/feature_engineering.py
@@ -41,6 +41,7 @@ class FeatureEngineering:
         
         self.categorical_columns = fe_config.get("categorical_columns", ["city", "state"])
         self.encoding_method = fe_config.get("encoding_method", "label")
+        self.create_cyclical_features = fe_config.get("create_cyclical_features", False)
         
         # Create output directory
         self.output_dir.mkdir(parents=True, exist_ok=True)
@@ -118,6 +119,15 @@ class FeatureEngineering:
         df['week_of_year'] = df['datetime'].dt.isocalendar().week.astype(int)
         df['is_weekend'] = (df['day_of_week'] >= 5).astype(int)
         df['quarter'] = df['datetime'].dt.quarter
+
+        # Cyclical encoding for seasonal/time patterns
+        if self.create_cyclical_features:
+            df['month_sin'] = np.sin(2 * np.pi * df['month'] / 12.0)
+            df['month_cos'] = np.cos(2 * np.pi * df['month'] / 12.0)
+            df['week_of_year_sin'] = np.sin(2 * np.pi * df['week_of_year'] / 52.0)
+            df['week_of_year_cos'] = np.cos(2 * np.pi * df['week_of_year'] / 52.0)
+            df['hour_sin'] = np.sin(2 * np.pi * df['hour'] / 24.0)
+            df['hour_cos'] = np.cos(2 * np.pi * df['hour'] / 24.0)
         
         # Season (Indian seasons - from notebook)
         def get_season(month):
@@ -302,6 +312,10 @@ class FeatureEngineering:
                 'year', 'month', 'day', 'hour', 'day_of_week', 'day_name',
                 'week_of_year', 'is_weekend', 'quarter', 'season', 'time_of_day'
             ],
+            "cyclical_features": [
+                'month_sin', 'month_cos', 'week_of_year_sin',
+                'week_of_year_cos', 'hour_sin', 'hour_cos'
+            ] if self.create_cyclical_features else [],
             "derived_features": [
                 'humidity_category', 'wind_category', 'is_raining', 'heavy_rain',
                 'aqi_category', 'pm25_category_india', 'festival_period', 'crop_burning_season'


### PR DESCRIPTION
### Motivation
- Reduce over-correction from seasonal priors by making seasonal multipliers more conservative and weather-aware.
- Avoid inflating model predictions by only applying a physics-based floor (`calculate_indian_aqi`) during truly severe pollution episodes.
- Preserve raw pollutant measurements for reporting while applying contextual bias to model inputs.
- Support time-based dataset splitting and optional cyclical datetime features for the feature pipeline.

### Description
- Added `apply_physics_floor` which uses `calculate_indian_aqi` and only enforces the CPCB floor when `pm2_5 >= 250` or `pm10 >= 350`, and integrated it into `predict_city_aqi`, `process_single_city`, and batch prediction flows. 
- Reworked seasonal logic: `get_seasonal_multiplier` values were made more conservative and a `_weather_damping_factor` was added to scale seasonal boosts based on `cloud_cover` and `wind_speed_10m`, and `apply_indian_context_bias` now uses an `effective_multiplier` derived from both season and weather. 
- `prepare_features` now saves raw pollutant columns (`raw_pm2_5`, `raw_pm10`, `raw_nitrogen_dioxide`) before applying context bias and the API output uses those raw values for reporting. 
- Feature engineering now supports optional cyclical datetime encoding (`month_sin`, `month_cos`, `week_of_year_sin`, `week_of_year_cos`, `hour_sin`, `hour_cos`) controlled by `feature_engineering.create_cyclical_features` in `params.yaml`, and metrics include the generated cyclical features. 
- Data splitting gained a `split_method` option; implemented a temporal (time-ordered, no-shuffle) split path when `split_method: "time"` is configured and adjusted stratification behavior and logging accordingly. 
- Updated `params.yaml` to enable `create_cyclical_features: true` and set `data_splitting.split_method: "time"` with `stratify: false` by default for temporal splitting workflows.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a18555e55c8330b6ea64835a1e0aca)