### PR TITLE
Fix README line 7 Docker badge formatting

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,7 +4,7 @@
 
 [![Python 3.10](https://img.shields.io/badge/Python-3.10-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.104.0-009688?style=for-the-badge&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
-[![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?style=for-the-badge&logo=docker&logoColor=white)](https://hub.docker.com/r/bhautikvekariya21/aqi-prediction-api)
+[![Docker Hub](https://img.shields.io/badge/Docker%20Hub-Image-2496ED?style=for-the-badge&logo=docker&logoColor=white)](https://hub.docker.com/r/bhautikvekariya21/aqi-prediction-api)
 [![Hugging Face](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Deployed-FFD21E?style=for-the-badge)](https://huggingface.co/spaces/bhautikvekariya21/aqi-prediction-mlops)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
### Motivation
- Fix a reported rendering error at line 7 of `ReadMe.md` by making the Docker/shields badge label and text safe for Markdown renderers.

### Description
- Updated the badge on line 7 of `ReadMe.md` to use a clearer label (`Docker Hub`) and URL-encoded badge text (`Docker%20Hub`) and normalized the file trailing newline.

### Testing
- Verified the change and file content with `sed -n '7p' ReadMe.md`, `nl -ba ReadMe.md | sed -n '1,20p'`, and `git diff -- ReadMe.md`, and committed the change with `git commit`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a281f09f6883309f0d8f2074b0780c)